### PR TITLE
GH-25: Reaccess now always passed on to subscription even prior to ge…

### DIFF
--- a/server/rescache/resourceSubscription.go
+++ b/server/rescache/resourceSubscription.go
@@ -130,8 +130,9 @@ func (rs *ResourceSubscription) Unsubscribe(sub Subscriber) {
 }
 
 func (rs *ResourceSubscription) handleEvent(r *ResourceEvent) {
-	// Discard if event happened before resource was loaded
-	if rs.state <= stateRequested {
+	// Discard if event happened before resource was loaded,
+	// unless it is a reaccess. Then we let the event be passed further.
+	if rs.state <= stateRequested && r.Event != "reaccess" {
 		return
 	}
 

--- a/server/wsConn.go
+++ b/server/wsConn.go
@@ -477,9 +477,6 @@ func (c *wsConn) removeCount(s *Subscription, direct bool, count int, tryDelete 
 		s.direct -= count
 	} else {
 		s.indirect -= count
-		// If we just removed the last indirect, while it is directly subscribed,
-		// the subscription might no longer have access. Time to ensure access.
-		s.EnsureAccess()
 	}
 
 	if tryDelete {

--- a/test/01subscribe_test.go
+++ b/test/01subscribe_test.go
@@ -233,6 +233,12 @@ func TestSubscribe(t *testing.T) {
 						reqs[treq.Subject] = treq
 					}
 					req.RespondSuccess(json.RawMessage(`{"get":true}`))
+				case "accessDenied":
+					for req = reqs["access."+ev.RID]; req == nil; req = reqs["access."+ev.RID] {
+						treq := s.GetRequest(t)
+						reqs[treq.Subject] = treq
+					}
+					req.RespondSuccess(json.RawMessage(`{"get":false}`))
 				case "get":
 					for req = reqs["get."+ev.RID]; req == nil; req = reqs["get."+ev.RID] {
 						req = s.GetRequest(t)
@@ -279,6 +285,9 @@ func TestSubscribe(t *testing.T) {
 						m["errors"] = errors
 					}
 					creq.GetResponse(t).AssertResult(t, m)
+				case "errorResponse":
+					creq = creqs[ev.RID]
+					creq.GetResponse(t).AssertIsError(t)
 				case "event":
 					s.ResourceEvent(ev.RID, "custom", event)
 					c.GetEvent(t).Equals(t, ev.RID+".custom", event)

--- a/test/10reaccess_event_test.go
+++ b/test/10reaccess_event_test.go
@@ -65,7 +65,7 @@ func TestReaccessEventTriggersUnsubscribeOnDeniedAccessCall(t *testing.T) {
 		// Get linked model
 		subscribeToTestModelParent(t, s, c, false)
 
-		// Change token
+		// Send reaccess event
 		s.ResourceEvent("test.model.parent", "reaccess", nil)
 
 		// Handle access requests with access denied
@@ -81,37 +81,6 @@ func TestReaccessEventTriggersUnsubscribeOnDeniedAccessCall(t *testing.T) {
 		// Send event on model parent and validate client event
 		s.ResourceEvent("test.model.parent", "custom", event)
 		c.AssertNoEvent(t, "test.model.parent")
-	})
-}
-
-// Test that unsubscribing a parent resource triggers a new access call on the child.
-func TestUnsubscribingParentTriggersAccessCall(t *testing.T) {
-	runTest(t, func(s *Session) {
-		event := json.RawMessage(`{"foo":"bar"}`)
-
-		c := s.Connect()
-
-		// Get linked model
-		subscribeToTestModelParent(t, s, c, false)
-
-		// Subscribe to child
-		c.Request("subscribe.test.model", nil).GetResponse(t).AssertResult(t, json.RawMessage(`{}`))
-
-		// Call unsubscribe on parent
-		c.Request("unsubscribe.test.model.parent", nil).GetResponse(t)
-
-		// Assert we get a new access request on child model
-		req := s.GetRequest(t).AssertSubject(t, "access.test.model")
-
-		// Send event on model and validate no client event
-		s.ResourceEvent("test.model", "custom", event)
-		c.AssertNoEvent(t, "test.model")
-
-		// Respond with access
-		req.RespondSuccess(json.RawMessage(`{"get":true}`))
-
-		// Assert that the event is now sent
-		c.GetEvent(t).Equals(t, "test.model.custom", event)
 	})
 }
 
@@ -166,5 +135,154 @@ func TestReaccessEventQueuesEvents(t *testing.T) {
 
 		// Assert that the parent event is now sent
 		c.GetEvent(t).Equals(t, "test.model.parent.custom", event)
+	})
+}
+
+// Test that a reaccess event sent prior to the get response is not discarded
+// and that the resource is unsubscribed if access is denied.
+func TestReaccessSentBeforeGetResponseDenyingAccess(t *testing.T) {
+	runTest(t, func(s *Session) {
+		model := resourceData("test.model")
+
+		c := s.Connect()
+		creq := c.Request("subscribe.test.model", nil)
+
+		// Handle only model access request
+		mreqs := s.GetParallelRequests(t, 2)
+		mreqs.GetRequest(t, "access.test.model").
+			RespondSuccess(json.RawMessage(`{"get":true}`))
+
+		// Send reaccess event
+		s.ResourceEvent("test.model", "reaccess", nil)
+
+		// Then handle the get request
+		mreqs.GetRequest(t, "get.test.model").
+			RespondSuccess(json.RawMessage(`{"model":` + model + `}`))
+
+		// Validate client response
+		creq.GetResponse(t).AssertResult(t, json.RawMessage(`{"models":{"test.model":`+model+`}}`))
+
+		// Assert we get a new access request on model due to the reaccess
+		s.GetRequest(t).AssertSubject(t, "access.test.model").
+			RespondSuccess(json.RawMessage(`{"get":false}`))
+
+		// Validate unsubscribe event
+		c.GetEvent(t).AssertEventName(t, "test.model.unsubscribe")
+	})
+}
+
+// Test that a reaccess event sent prior to the get response is not discarded
+// and that the resource is still subscribed after access is re-granted.
+func TestReaccessSentBeforeGetResponseGrantingAccess(t *testing.T) {
+	runTest(t, func(s *Session) {
+		model := resourceData("test.model")
+		event := json.RawMessage(`{"foo":"bar"}`)
+
+		c := s.Connect()
+		creq := c.Request("subscribe.test.model", nil)
+
+		// Handle only model access request
+		mreqs := s.GetParallelRequests(t, 2)
+		mreqs.GetRequest(t, "access.test.model").
+			RespondSuccess(json.RawMessage(`{"get":true}`))
+
+		// Send reaccess event
+		s.ResourceEvent("test.model", "reaccess", nil)
+
+		// Then handle the get request
+		mreqs.GetRequest(t, "get.test.model").
+			RespondSuccess(json.RawMessage(`{"model":` + model + `}`))
+
+		// Validate client response
+		creq.GetResponse(t).AssertResult(t, json.RawMessage(`{"models":{"test.model":`+model+`}}`))
+
+		// Assert we get a new access request on model due to the reaccess
+		s.GetRequest(t).AssertSubject(t, "access.test.model").
+			RespondSuccess(json.RawMessage(`{"get":true}`))
+
+		// Send event on model and validate client event
+		s.ResourceEvent("test.model", "custom", event)
+		c.GetEvent(t).Equals(t, "test.model.custom", event)
+	})
+}
+
+// Test that a reaccess event sent on a cyclic reference causes an access request.
+func TestReaccessOnCyclicReference(t *testing.T) {
+	runTest(t, func(s *Session) {
+		model := resourceData("test.m.a")
+
+		c := s.Connect()
+		creq := c.Request("subscribe.test.m.a", nil)
+
+		// Handle only model access request
+		mreqs := s.GetParallelRequests(t, 2)
+		mreqs.GetRequest(t, "get.test.m.a").
+			RespondSuccess(json.RawMessage(`{"model":` + model + `}`))
+		mreqs.GetRequest(t, "access.test.m.a").
+			RespondSuccess(json.RawMessage(`{"get":true}`))
+
+		// Validate client response
+		creq.GetResponse(t).AssertResult(t, json.RawMessage(`{"models":{"test.m.a":`+model+`}}`))
+
+		// Send reaccess event
+		s.ResourceEvent("test.m.a", "reaccess", nil)
+
+		// Assert we get a new access request on model due to the reaccess
+		s.GetRequest(t).AssertSubject(t, "access.test.m.a").
+			RespondSuccess(json.RawMessage(`{"get":true}`))
+	})
+}
+
+// Test multiple reaccess events while queueing only results in one access request
+func TestMultipleReaccessEventsWhileQueueing(t *testing.T) {
+	runTest(t, func(s *Session) {
+		model := resourceData("test.model")
+		event := json.RawMessage(`{"foo":"bar"}`)
+
+		c := s.Connect()
+		creq := c.Request("subscribe.test.model", nil)
+
+		// Handle only model access request
+		mreqs := s.GetParallelRequests(t, 2)
+		mreqs.GetRequest(t, "access.test.model").
+			RespondSuccess(json.RawMessage(`{"get":true}`))
+
+		// Send multiple reaccess event
+		s.ResourceEvent("test.model", "reaccess", nil)
+		s.ResourceEvent("test.model", "reaccess", nil)
+
+		// Then handle the get request
+		mreqs.GetRequest(t, "get.test.model").
+			RespondSuccess(json.RawMessage(`{"model":` + model + `}`))
+
+		// Validate client response
+		creq.GetResponse(t).AssertResult(t, json.RawMessage(`{"models":{"test.model":`+model+`}}`))
+
+		// Assert we get a new access request on model due to the reaccess
+		s.GetRequest(t).AssertSubject(t, "access.test.model").
+			RespondSuccess(json.RawMessage(`{"get":true}`))
+
+		// Send event on model and validate client event
+		s.ResourceEvent("test.model", "custom", event)
+		c.GetEvent(t).Equals(t, "test.model.custom", event)
+	})
+}
+
+// Test that a reaccess event on an indirect subscription is discarded.
+func TestReaccessEventOnIndirectResources(t *testing.T) {
+	runTest(t, func(s *Session) {
+		event := json.RawMessage(`{"foo":"bar"}`)
+
+		c := s.Connect()
+
+		// Get linked model
+		subscribeToTestModelParent(t, s, c, false)
+
+		// Send reaccess event
+		s.ResourceEvent("test.model", "reaccess", nil)
+
+		// Send event on child model and validate client event
+		s.ResourceEvent("test.model", "custom", event)
+		c.GetEvent(t).Equals(t, "test.model.custom", event)
 	})
 }

--- a/test/14http_get_test.go
+++ b/test/14http_get_test.go
@@ -128,6 +128,12 @@ func TestHTTPGet(t *testing.T) {
 							reqs[treq.Subject] = treq
 						}
 						req.RespondSuccess(json.RawMessage(`{"get":true}`))
+					case "accessDenied":
+						for req = reqs["access."+ev.RID]; req == nil; req = reqs["access."+ev.RID] {
+							treq := s.GetRequest(t)
+							reqs[treq.Subject] = treq
+						}
+						req.RespondSuccess(json.RawMessage(`{"get":false}`))
 					case "get":
 						for req = reqs["get."+ev.RID]; req == nil; req = reqs["get."+ev.RID] {
 							req = s.GetRequest(t)
@@ -145,6 +151,9 @@ func TestHTTPGet(t *testing.T) {
 					case "response":
 						hreq = hreqs[ev.RID]
 						hreq.GetResponse(t).Equals(t, http.StatusOK, json.RawMessage(enc.Responses[ev.RID]))
+					case "errorResponse":
+						hreq = hreqs[ev.RID]
+						hreq.GetResponse(t).AssertIsError(t)
 					}
 				}
 			}, func(c *server.Config) {

--- a/test/http.go
+++ b/test/http.go
@@ -133,6 +133,21 @@ func (hr *HTTPResponse) AssertErrorCode(t *testing.T, code string) *HTTPResponse
 	return hr
 }
 
+// AssertIsError asserts that the response does not have status 200,
+// and that the body has an error code.
+func (hr *HTTPResponse) AssertIsError(t *testing.T) *HTTPResponse {
+	if hr.Code == http.StatusOK {
+		t.Fatalf("expected response code not to be 200, but it was")
+	}
+
+	var rerr reserr.Error
+	err := json.Unmarshal(hr.Body.Bytes(), &rerr)
+	if err != nil || rerr.Code == "" {
+		t.Fatalf("expected error response, but got body:\n%s", hr.Body.String())
+	}
+	return hr
+}
+
 // AssertHeaders asserts that the response includes the expected headers
 func (hr *HTTPResponse) AssertHeaders(t *testing.T, h map[string]string) *HTTPResponse {
 	for k, v := range h {

--- a/test/resources.go
+++ b/test/resources.go
@@ -149,7 +149,7 @@ var sequenceTable = [][]sequenceEvent{
 		{"event", "test.model.brokenchild"},
 		{"noevent", "test.err.notFound"},
 	},
-	// Cyclic tests
+	// Cyclic model tests
 	{
 		{"subscribe", "test.m.a"},
 		{"access", "test.m.a"},
@@ -241,7 +241,7 @@ var sequenceTable = [][]sequenceEvent{
 		{"event", "test.collection.brokenchild"},
 		{"noevent", "test.err.notFound"},
 	},
-	// Cyclic tests
+	// Cyclic collection tests
 	{
 		{"subscribe", "test.c.a"},
 		{"access", "test.c.a"},
@@ -283,5 +283,30 @@ var sequenceTable = [][]sequenceEvent{
 		{"get", "test.c.f"},
 		{"response", "test.c.d"},
 		{"response", "test.c.h"},
+	},
+	// Access test
+	{
+		{"subscribe", "test.model.parent"},
+		{"access", "test.model.parent"},
+		{"get", "test.model.parent"},
+		{"get", "test.model"},
+		{"response", "test.model.parent"},
+		{"subscribe", "test.model"},
+		{"access", "test.model"},
+		{"response", "test.model"},
+		{"event", "test.model.parent"},
+		{"event", "test.model"},
+	},
+	{
+		{"subscribe", "test.model.parent"},
+		{"access", "test.model.parent"},
+		{"get", "test.model.parent"},
+		{"get", "test.model"},
+		{"response", "test.model.parent"},
+		{"subscribe", "test.model"},
+		{"accessDenied", "test.model"},
+		{"errorResponse", "test.model"},
+		{"event", "test.model.parent"},
+		{"event", "test.model"},
 	},
 }

--- a/test/ws.go
+++ b/test/ws.go
@@ -299,15 +299,7 @@ func (cr *ClientResponse) AssertResult(t *testing.T, result interface{}) *Client
 
 // AssertError asserts that the response has the expected error
 func (cr *ClientResponse) AssertError(t *testing.T, err *reserr.Error) *ClientResponse {
-	// Assert it is an error
-	if cr.Error == nil {
-		var err error
-		rj, err := json.Marshal(cr.Result)
-		if err != nil {
-			panic("test: error marshaling response result: " + err.Error())
-		}
-		t.Fatalf("expected error response, but got result:\n%s", rj)
-	}
+	cr.AssertIsError(t)
 
 	if !reflect.DeepEqual(err, cr.Error) {
 		ej, err := json.Marshal(err)
@@ -325,6 +317,16 @@ func (cr *ClientResponse) AssertError(t *testing.T, err *reserr.Error) *ClientRe
 
 // AssertErrorCode asserts that the response has the expected error code
 func (cr *ClientResponse) AssertErrorCode(t *testing.T, code string) *ClientResponse {
+	cr.AssertIsError(t)
+
+	if cr.Error.Code != code {
+		t.Fatalf("expected response error code to be:\n%#v\nbut got:\n%#v", code, cr.Error.Code)
+	}
+	return cr
+}
+
+// AssertIsError asserts that the response is an error
+func (cr *ClientResponse) AssertIsError(t *testing.T) *ClientResponse {
 	// Assert it is an error
 	if cr.Error == nil {
 		var err error
@@ -335,9 +337,6 @@ func (cr *ClientResponse) AssertErrorCode(t *testing.T, code string) *ClientResp
 		t.Fatalf("expected error response, but got result:\n%s", rj)
 	}
 
-	if cr.Error.Code != code {
-		t.Fatalf("expected response error code to be:\n%#v\nbut got:\n%#v", code, cr.Error.Code)
-	}
 	return cr
 }
 


### PR DESCRIPTION
…t request.

Access request now made on subscribe to indirect subscribed resource.
Added tests for more reaccess and subscription cases.