### PR TITLE
Feature/gh 108 support nats user credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ func (c *Config) Init(fs *flag.FlagSet, args []string) error {
 			} else {
 				c.HeaderAuth = &headauth
 			}
-		case "natscreds":
+		case "creds":
 			if natsCreds == "" {
 				c.NatsCreds = nil
 			} else {

--- a/nats/nats.go
+++ b/nats/nats.go
@@ -22,6 +22,7 @@ const logPrefix = "[NATS] "
 type Client struct {
 	RequestTimeout time.Duration
 	URL            string
+	Creds          *string
 	Logger         logger.Logger
 
 	mq      *nats.Conn
@@ -75,8 +76,14 @@ func (c *Client) Connect() error {
 
 	c.Logf("Connecting to NATS at %s", c.URL)
 
+	// Create connection options
+	opts := []nats.Option{nats.NoReconnect()}
+	if c.Creds != nil {
+		opts = append(opts, nats.UserCredentials(*c.Creds))
+	}
+
 	// No reconnects as all resources are instantly stale anyhow
-	nc, err := nats.Connect(c.URL, nats.NoReconnect())
+	nc, err := nats.Connect(c.URL, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Testing done manually covering:

* Connecting to nats-server using credentials file provided by command line
* Connecting to nats-server using credentials file provided by config
* Failing to connect to nats-server  without credentials file
* Failing to load missing credentials file
* Connecting to open nats-server with credentials file configured
* Connecting to open nats-server without credentials file