### PR TITLE
GH-124: Updated docker files to Go 1.13.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM golang
 
-WORKDIR $GOPATH/src/github.com/resgateio/resgate
+ENV GO111MODULE=on
+
+WORKDIR /src/resgate
+
 COPY . .
 
-RUN go get -d -v
-RUN CGO_ENABLED=0 GO111MODULE=off go install -v -ldflags "-s -w"
+RUN CGO_ENABLED=0 go build -v -ldflags "-s -w" -o /resgate
 
 EXPOSE 8080
 
-ENTRYPOINT ["resgate"]
+ENTRYPOINT ["/resgate"]
 CMD ["--help"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,28 +1,24 @@
-FROM golang:1.12.5-alpine3.9 as builder
+FROM golang:1.13.1-alpine3.10 as builder
 
 LABEL maintainer="Samuel Jirenius <samuel@jirenius.com>"
 
-WORKDIR $GOPATH/src/github.com/resgateio/resgate
+ENV GO111MODULE=on
 
-RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
-RUN mkdir /user && \
-	echo 'nobody:x:65534:65534:nobody:/:' > /user/passwd && \
-	echo 'nobody:x:65534:' > /user/group
+WORKDIR /src/resgate
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
 
 COPY . .
 
-RUN go get -d -v
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build -v -ldflags "-s -w" -o /resgate
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-s -w" -o /resgate
 
 FROM scratch
-
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /user/group /user/passwd /etc/
 COPY --from=builder /resgate /resgate
 
 EXPOSE 8080
 
-USER nobody:nobody
-
 ENTRYPOINT ["/resgate"]
-CMD ["--config", "config.json"]
+CMD [""]

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,20 +1,21 @@
-FROM golang:1.12.5-alpine3.9 as builder
+FROM golang:1.13.1-alpine3.10 as builder
 
 LABEL maintainer="Samuel Jirenius <samuel@jirenius.com>"
 
-WORKDIR $GOPATH/src/github.com/resgateio/resgate
+ENV GO111MODULE=on
 
-RUN apk add --update git
+WORKDIR /src/resgate
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
 
 COPY . .
 
-RUN go get -d -v
-RUN GO111MODULE=off go build -v -ldflags "-s -w" -o /resgate
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-s -w" -o /resgate
 
-FROM alpine:3.9
-
-RUN apk add --update ca-certificates
-
+FROM alpine:3.10
 COPY --from=builder /resgate /bin/resgate
 
 EXPOSE 8080


### PR DESCRIPTION
Removed unnecessary certificates from build.
Updated to support go modules.